### PR TITLE
Added support for association groups

### DIFF
--- a/main.js
+++ b/main.js
@@ -258,7 +258,111 @@ var adapter = utils.adapter({
                     } else {
                         if (obj.callback) adapter.sendTo(obj.from, obj.command, {error: 'not runnung'}, obj.callback);
                     }
-                    break;
+					break;
+
+				// Association groups management functions:
+				case 'getNumGroups': // zwave.getNumGroups(nodeid) => number;
+					if (zwave && obj.message) {
+						disableInclusion();
+						disableExclusion();
+						adapter.log.info('Requesting number of association groups from node' + obj.message.nodeID);
+						if (zwave[obj.command]) {
+							var result = zwave[obj.command](obj.message.nodeID);
+							if (obj.callback) adapter.sendTo(obj.from, obj.command, { error: null, result: result }, obj.callback);
+						} else {
+							adapter.log.error('Unknown command!');
+							if (obj.callback) adapter.sendTo(obj.from, obj.command, { error: 'Unknown command!' }, obj.callback);
+						}
+					} else {
+						if (obj.callback) adapter.sendTo(obj.from, obj.command, { error: 'not runnung' }, obj.callback);
+					}
+					break;
+
+				case 'getGroupLabel': // zwave.getGroupLabel(nodeid, group) => string;
+					if (zwave && obj.message) {
+						disableInclusion();
+						disableExclusion();
+						adapter.log.info('Requesting label of association group ' + obj.message.group + ' from node ' + obj.message.nodeID);
+						if (zwave[obj.command]) {
+							var result = zwave[obj.command](obj.message.nodeID, obj.message.group);
+							if (obj.callback) adapter.sendTo(obj.from, obj.command, { error: null, result: result }, obj.callback);
+						} else {
+							adapter.log.error('Unknown command!');
+							if (obj.callback) adapter.sendTo(obj.from, obj.command, { error: 'Unknown command!' }, obj.callback);
+						}
+					} else {
+						if (obj.callback) adapter.sendTo(obj.from, obj.command, { error: 'not runnung' }, obj.callback);
+					}
+					break;
+
+				case 'getAssociations': // zwave.getAssociations(nodeid, group);
+					if (zwave && obj.message) {
+						disableInclusion();
+						disableExclusion();
+						adapter.log.info('Requesting associations in group ' + obj.message.group + ' from node ' + obj.message.nodeID);
+						if (zwave[obj.command]) {
+							var result = zwave[obj.command](obj.message.nodeID, obj.message.group);
+							if (obj.callback) adapter.sendTo(obj.from, obj.command, { error: null, result: result }, obj.callback);
+						} else {
+							adapter.log.error('Unknown command!');
+							if (obj.callback) adapter.sendTo(obj.from, obj.command, { error: 'Unknown command!' }, obj.callback);
+						}
+					} else {
+						if (obj.callback) adapter.sendTo(obj.from, obj.command, { error: 'not runnung' }, obj.callback);
+					}
+					break;
+
+				case 'getMaxAssociations': // zwave.getMaxAssociations(nodeid, group);
+					if (zwave && obj.message) {
+						disableInclusion();
+						disableExclusion();
+						adapter.log.info('Requesting max number of associations in group ' + obj.message.group + ' from node ' + obj.message.nodeID);
+						if (zwave[obj.command]) {
+							var result = zwave[obj.command](obj.message.nodeID, obj.message.group);
+							if (obj.callback) adapter.sendTo(obj.from, obj.command, { error: null, result: result }, obj.callback);
+						} else {
+							adapter.log.error('Unknown command!');
+							if (obj.callback) adapter.sendTo(obj.from, obj.command, { error: 'Unknown command!' }, obj.callback);
+						}
+					} else {
+						if (obj.callback) adapter.sendTo(obj.from, obj.command, { error: 'not runnung' }, obj.callback);
+					}
+					break;
+
+				case 'addAssociation': // zwave.addAssociation(nodeid, group, target_nodeid);
+					if (zwave && obj.message) {
+						disableInclusion();
+						disableExclusion();
+						adapter.log.info('Adding association with node ' + obj.message.target_nodeid + ' to group ' + obj.message.group + ' of node ' + obj.message.nodeID);
+						if (zwave[obj.command]) {
+							zwave[obj.command](obj.message.nodeID, obj.message.group, obj.message.target_nodeid);
+							if (obj.callback) adapter.sendTo(obj.from, obj.command, { error: null, result: 'ok' }, obj.callback);
+						} else {
+							adapter.log.error('Unknown command!');
+							if (obj.callback) adapter.sendTo(obj.from, obj.command, { error: 'Unknown command!' }, obj.callback);
+						}
+					} else {
+						if (obj.callback) adapter.sendTo(obj.from, obj.command, { error: 'not runnung' }, obj.callback);
+					}
+					break;
+
+				case 'removeAssociation': // zwave.removeAssociation(nodeid, group, target_nodeid);
+					if (zwave && obj.message) {
+						disableInclusion();
+						disableExclusion();
+						adapter.log.info('Removing association with node ' + obj.message.target_nodeid + ' from group ' + obj.message.group + ' of node ' + obj.message.nodeID);
+						if (zwave[obj.command]) {
+							zwave[obj.command](obj.message.nodeID, obj.message.group, obj.message.target_nodeid);
+							if (obj.callback) adapter.sendTo(obj.from, obj.command, { error: null, result: 'ok' }, obj.callback);
+						} else {
+							adapter.log.error('Unknown command!');
+							if (obj.callback) adapter.sendTo(obj.from, obj.command, { error: 'Unknown command!' }, obj.callback);
+						}
+					} else {
+						if (obj.callback) adapter.sendTo(obj.from, obj.command, { error: 'not runnung' }, obj.callback);
+					}
+					break;
+
 
                 default:
                     adapter.log.error('Unknown command: ' + obj.command);

--- a/main.js
+++ b/main.js
@@ -115,9 +115,22 @@ var adapter = utils.adapter({
 		var predefinedResponses = {
 			OK: { error: null, result: 'ok' },
 			ERROR_UNKNOWN_COMMAND: { error: 'Unknown command!' },
-			ERROR_NOT_RUNNING: {error: 'zwave driver is not running!'}
+			ERROR_NOT_RUNNING: { error: 'zwave driver is not running!' },
+			MISSING_PARAMETER: function (paramName) { return { error: 'missing parameter "' + paramName + '"!' };}
+		}
+		// make required parameters easier
+		function requireParams(params) {
+			if (!(params && params.length)) return true;
+			for (var i = 0; i < params.length; i++) {
+				if (!(obj.message && obj.message.hasOwnProperty(params[i]))) {
+					respond(predefinedResponses.MISSING_PARAMETER(params[i]));
+					return false;
+				}
+			}
+			return true;
 		}
 
+		// handle the message
         if (obj) {
             addNodeSecure = false;
             switch (obj.command) {
@@ -276,8 +289,11 @@ var adapter = utils.adapter({
 				// Association groups management functions:
 				case 'getNumGroups': // zwave.getNumGroups(nodeid) => number;
 					if (zwave && obj.message) {
+						if (!requireParams(["nodeID"])) break;
+
 						disableInclusion();
 						disableExclusion();
+
 						adapter.log.info('Requesting number of association groups from node' + obj.message.nodeID);
 						if (zwave[obj.command]) {
 							var result = zwave[obj.command](obj.message.nodeID);
@@ -293,8 +309,11 @@ var adapter = utils.adapter({
 
 				case 'getGroupLabel': // zwave.getGroupLabel(nodeid, group) => string;
 					if (zwave && obj.message) {
+						if (!requireParams(["nodeID", "group"])) break;
+
 						disableInclusion();
 						disableExclusion();
+
 						adapter.log.info('Requesting label of association group ' + obj.message.group + ' from node ' + obj.message.nodeID);
 						if (zwave[obj.command]) {
 							var result = zwave[obj.command](obj.message.nodeID, obj.message.group);
@@ -310,8 +329,11 @@ var adapter = utils.adapter({
 
 				case 'getAssociations': // zwave.getAssociations(nodeid, group);
 					if (zwave && obj.message) {
+						if (!requireParams(["nodeID", "group"])) break;
+
 						disableInclusion();
 						disableExclusion();
+
 						adapter.log.info('Requesting associations in group ' + obj.message.group + ' from node ' + obj.message.nodeID);
 						if (zwave[obj.command]) {
 							var result = zwave[obj.command](obj.message.nodeID, obj.message.group);
@@ -327,8 +349,11 @@ var adapter = utils.adapter({
 
 				case 'getMaxAssociations': // zwave.getMaxAssociations(nodeid, group);
 					if (zwave && obj.message) {
+						if (!requireParams(["nodeID", "group"])) break;
+
 						disableInclusion();
 						disableExclusion();
+
 						adapter.log.info('Requesting max number of associations in group ' + obj.message.group + ' from node ' + obj.message.nodeID);
 						if (zwave[obj.command]) {
 							var result = zwave[obj.command](obj.message.nodeID, obj.message.group);
@@ -344,8 +369,11 @@ var adapter = utils.adapter({
 
 				case 'addAssociation': // zwave.addAssociation(nodeid, group, target_nodeid);
 					if (zwave && obj.message) {
+						if (!requireParams(["nodeID", "group", "target_nodeid"])) break;
+
 						disableInclusion();
 						disableExclusion();
+
 						adapter.log.info('Adding association with node ' + obj.message.target_nodeid + ' to group ' + obj.message.group + ' of node ' + obj.message.nodeID);
 						if (zwave[obj.command]) {
 							zwave[obj.command](obj.message.nodeID, obj.message.group, obj.message.target_nodeid);
@@ -361,8 +389,11 @@ var adapter = utils.adapter({
 
 				case 'removeAssociation': // zwave.removeAssociation(nodeid, group, target_nodeid);
 					if (zwave && obj.message) {
+						if (!requireParams(["nodeID", "group", "target_nodeid"])) break;
+
 						disableInclusion();
 						disableExclusion();
+
 						adapter.log.info('Removing association with node ' + obj.message.target_nodeid + ' from group ' + obj.message.group + ' of node ' + obj.message.nodeID);
 						if (zwave[obj.command]) {
 							zwave[obj.command](obj.message.nodeID, obj.message.group, obj.message.target_nodeid);


### PR DESCRIPTION
The zwave management functions for groups and associations can now be accessed via ```sendTo```. Example:
```
sendTo("zwave.0", "getAssociations", {nodeID: 2, group: 1}, (obj) => {
    if (obj.error) {
        log(obj.error, "error");
    } else {
        log(`group ${group} associations: ` + obj.result);
    }
});
```
Supported functions:  
```getNumGroups```: with param ```nodeID```. Returns ```<number>```  
```getGroupLabel```: with params ```nodeID``` and ```group``` (range 1..numGroups). Returns ```<string>```  
```getAssociations```: with params ```nodeID``` and ```group``` (range 1..numGroups). Returns ```<number[]>```  
```getMaxAssociations```: with params ```nodeID``` and ```group``` (range 1..numGroups). Returns ```<number>```  
```addAssociation```: with params ```nodeID```, ```group``` (range 1..numGroups) and ```target_nodeid```. Returns 'ok'  
```removeAssociation```: with params ```nodeID```, ```group``` (range 1..numGroups) and ```target_nodeid```. Returns 'ok'

---

Also cleaned up the message handling code a bit to reduce repeated code.  