### PR TITLE
Loslassen von Buttons unterstützen

### DIFF
--- a/main.js
+++ b/main.js
@@ -608,6 +608,41 @@ function delObjects(list, callback) {
     }
 }
 
+// This fixes existing zwave state objects, so they are using role="switch" instead of role="button"
+// because Zwave buttons support two states. Call 
+function fixZwaveButtons(callback) {
+    adapter.log.debug('fixing zwave buttons to use common.role "switch" instead of "button"');
+    // Find all state objects representing a zwave button
+    var stateObjs = Object.keys(objects)
+        .filter(function (id) { return id.startsWith(adapter.namespace); })
+        .map(function (id) { return objects[id] })
+        .filter(function (obj) { return obj.type === "state" && obj.common.role === "button" && obj.native.type === "button"; })
+        ;
+    if (!(stateObjs && stateObjs.length > 0)) {
+        // no objects to fix, return immediately
+        if (callback) callback();
+        return;
+    } else {
+        adapter.log.debug('found ' + stateObjs.length + ' states to fix');
+        doFix(stateObjs);
+    }
+
+    function doFix(list) {
+        if (!list.length) {
+            adapter.log.debug('done fixing states');
+            if (callback) callback();
+            return;
+        }
+
+        var obj = list.pop();
+        var id = obj.id || obj._id;
+        obj.common.role = "switch";
+        adapter.setObject(id, obj, function (err) {
+            setTimeout(doFix, 0, list);
+        });
+    }
+}
+
 function calcName(nodeID, comClass, idx, instance) {
     var name = adapter.namespace + '.NODE' + nodeID;
     if (comClass) {
@@ -862,15 +897,17 @@ function extendChannel(nodeID, comClass, valueId) {
             type:   'state',
             _id:    stateID
         };
-        if (valueId.units)               stateObj.common.unit = valueId.units;
+        if (valueId.units) stateObj.common.unit = valueId.units;
 
         if (valueId.type === 'byte' || valueId.type === 'int' || valueId.type === 'decimal' || valueId.type === 'short') stateObj.common.type = 'number';
         if (valueId.type === 'bool') stateObj.common.type = 'boolean';
         if (valueId.type === 'string') stateObj.common.type = 'string';
 
         if (valueId.type === 'button') {
-            stateObj.common.type  = 'boolean';
-            stateObj.common.role  = 'button';
+            stateObj.common.type = 'boolean';
+            // TODO: in the long run, this should be a special role which supports 3 states:
+            // neutral, pressed => sends true, released => sends false
+            stateObj.common.role  = 'switch';
             stateObj.common.write = true;
             stateObj.common.read  = false;
         }
@@ -1006,7 +1043,10 @@ function main() {
                 }
             }
         }
-        delObjects(list);
+        delObjects(list, function () {
+            // after deleting unneccessary devices, fix button states
+            fixZwaveButtons();
+        });
     });
 
     // ------------- nodes events ---------------------------


### PR DESCRIPTION
Dies ist ein Teil der Lösung des Problems in http://forum.iobroker.net/viewtopic.php?p=83244#p83244

Im OZW master branch wurde heute ein teilweiser Fix eingespielt, sodass Anhalten von Rolläden unterstützt wird. Close/Dec-Buttons sind leider weiterhin ohne Funktion.

Zudem hat node-openzwave-shared einen Bug (oder Feature?), dass beim Setzen von Werten, die intern ein Button sind, nur das Drücken, nicht das Loslassen simuliert wird. Das können wir aber umgehen, wofür dieser PR da ist.

Ich kann meine Rolläden beim Öffnen jetzt anhalten. Wegen Schließen müssen wir leider auf einen weiteren OZW-Patch warten.

---

Jetzt ist meine Frage: Die Buttons im Admin-Tab "Objekte" unterstützen ja leider auch nur Drücken, nicht loslassen. Kriegt man das irgendwie anders gelöst? Z.b. ein Taster mit 3 Zuständen: An (links gedrückt), Aus (rechts gedrückt), Neutral (mitte)