### PR TITLE
Use new OZW version for compatibility with NodeJS 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ Following global Actions are current supported:
 
 ## Changelog
 
+### 1.0.1 (2018-05-01)
+* (AlCalzone) Use new OZW version for compatibility with NodeJS 10
+
 ### 1.0.0 (2018-01-31)
 * (AlCalzone) Simplified resolving the location of the JS-Controller
 

--- a/io-package.json
+++ b/io-package.json
@@ -7,8 +7,13 @@
             "de": "ZWave-Unterstützung durch Openzwave Paket",
             "ru": "Поддержка ZWave основанная на Openzwave пакете"
         },
-        "version": "1.0.0",
+        "version": "1.0.1",
         "news": {
+            "1.0.1": {
+                "en": "Use new OZW version for compatibility with NodeJS 10",
+                "de": "Neue OZW-Version für Kompatibilität mit NodeJS 10 verwendet",
+                "ru": "Используйте новую версию OZW для совместимости с NodeJS 10"
+            },
             "1.0.0": {
                 "en": "Simplified resolving the location of the JS-Controller",
                 "de": "Vereinfachte Auflösung des JS-Controller Speicherorts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iobroker.zwave",
   "description": "ZWave support for ioBroker based on openzwave packet",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "bluefox",
     "email": "dogafox@gmail.com"
@@ -33,7 +33,7 @@
     "url": "git+https://github.com/ioBroker/ioBroker.zwave.git"
   },
   "dependencies": {
-    "openzwave-shared": "^1.4.0"
+    "openzwave-shared": "^1.4.3"
   },
   "devDependencies": {
     "@types/node": "^4.2.23",


### PR DESCRIPTION
In v1.4.3, Windows build support and NodeJS 10 compatibility was fixed.