### PR TITLE
Pin OZW version to 1.4

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,8 +4,9 @@ environment:
     - nodejs_version: '6'
     - nodejs_version: '8'
     - nodejs_version: '10'
-    - nodejs_version: '12'
-    - nodejs_version: ''
+    # Node 12 is blocked by https://github.com/OpenZWave/node-openzwave-shared/issues/280
+    # - nodejs_version: '12'
+    # - nodejs_version: ''
 platform:
   - x86
   - x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,6 @@ test_script:
   # Package tests fail for now because materialize is not supported
   # - npm run test:package
   - npm run test:unit
-  - export DEBUG=testing:*
+  - set DEBUG=testing:*
   - npm run test:integration
 build: 'off'

--- a/lib/preinstall.js
+++ b/lib/preinstall.js
@@ -140,10 +140,16 @@ function installOpenZwave() {
 }
 
 function installOpenZwaveFromSource() {
-  doScript('curl -L -O https://github.com/OpenZWave/open-zwave/archive/master.zip');
-  doScript('rm -rf open-zwave-master');
-  doScript('unzip master.zip && rm master.zip');
-  // 2019-05-03: PR #1125 has been merged today, which causes the command to fail.
-  // doScript('cd open-zwave-master && curl -O -L https://github.com/OpenZWave/open-zwave/pull/1125.patch && patch -p1 < 1125.patch');
-  doScript(`cd open-zwave-master && make && ${isRoot ? '' : 'sudo '}make install`);
+  // For now we manually have to install 1.4 because openzwave-shared is not compatible yet
+  const branch = '1.4';
+  doScript(`curl -L -O https://github.com/OpenZWave/open-zwave/archive/${branch}.zip`);
+  doScript(`rm -rf open-zwave-${branch}`);
+  doScript(`unzip ${branch}.zip && rm ${branch}.zip`);
+  try {
+  doScript(`cd open-zwave-${branch} && curl -O -L https://github.com/OpenZWave/open-zwave/pull/1125.patch && patch -p1 < 1125.patch`);
+  } catch (e) {
+    // Depending on which branch we target, PR #1125 might have been merged already,
+    // so this command will fail. No biggie though.
+  }
+  doScript(`cd open-zwave-${branch} && make && ${isRoot ? '' : 'sudo '}make install`);
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "url": "git+https://github.com/ioBroker/ioBroker.zwave.git"
   },
   "dependencies": {
-    "openzwave-shared": "^1.4.8",
+    "openzwave-shared": "AlCalzone/node-openzwave-shared#ozw-1.4",
     "@iobroker/adapter-core": "^1.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "url": "git+https://github.com/ioBroker/ioBroker.zwave.git"
   },
   "dependencies": {
-    "openzwave-shared": "^1.4.3",
+    "openzwave-shared": "^1.4.8",
     "@iobroker/adapter-core": "^1.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
hoping this fixes the breaks introduced by 1.6

Fixes: #48 

How to test:
* Delete OpenZWave: 
  * `/usr/local/lib64/libopenzwave.so` or any variants thereof (lib instead of lib64, .so files with version in the name, ...)
  * `/usr/local/include/openzwave` and its contents
* Uninstall ZWave adapter
* Reinstall ZWave adapter from custom URL https://github.com/ioBroker/ioBroker.zwave/tarball/install-v1.4