### PR TITLE
Cleanup obsolete states

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -556,6 +556,13 @@
         });
 
         $('.zwave-operations').each(function () {
+            if ($(this).data('operation') == 'hardReset') {
+                if (confirm(_('Are you sure you want to remove all devices?'))) {
+                    // just continue
+                } else {
+                    return false;
+                }
+            }
             $(this).button({
                 icons: {primary: 'ui-icon-custom-' + $(this).data('icon'), secondary: null}
             }).button('disable').click(function () {

--- a/admin/index.html
+++ b/admin/index.html
@@ -556,13 +556,6 @@
         });
 
         $('.zwave-operations').each(function () {
-            if ($(this).data('operation') == 'hardReset') {
-                if (confirm(_('Are you sure you want to remove all devices?'))) {
-                    // just continue
-                } else {
-                    return false;
-                }
-            }
             $(this).button({
                 icons: {primary: 'ui-icon-custom-' + $(this).data('icon'), secondary: null}
             }).button('disable').click(function () {

--- a/main.js
+++ b/main.js
@@ -834,6 +834,20 @@ function extendChannel(nodeID, comClass, valueId) {
 
     // Create channel
     if (objects[channelID]) {
+        // channel exists - make sure we don't have duplicate states
+        if (!nodes[nodeID].ready) {
+            for (var i in objects) {
+                if (!objects.hasOwnProperty(i)) continue;
+                if (i.startsWith(channelID + '.')) {
+                    if (objects[i].native && objects[i].native.instance === valueId.instance && objects[i].native.index === valueId.index &&
+                    objects[i].common.name !== valueId.label) {
+                        adapter.log.info('remove obsolete state:' + objects[i]._id);
+                        delObjects([objects[i]]);
+                    }
+                }
+            }
+        }
+        
         var newNative = objects[channelID].native || {};
         newNative.nodeID = nodeID;
 

--- a/main.js
+++ b/main.js
@@ -826,6 +826,26 @@ function extendNode(nodeID, nodeInfo, callback) {
     if (!count && callback) callback();
 }
 
+/*
+* Verify that we don't have duplicate valueIds (same node, instance and index but different label)
+* Can happen when the ozwave library changes labels for devices between releases
+*/
+function cleanupValueId(nodeID, comClass, valueId) {
+    const channelID = calcName(nodeID, comClass);
+    
+    for (var i in objects) {
+        if (!objects.hasOwnProperty(i)) continue;
+        if (i.startsWith(channelID + '.')) {
+            if (objects[i].native && objects[i].native.instance === valueId.instance && objects[i].native.index === valueId.index &&
+            objects[i].common.name !== valueId.label) {
+                adapter.log.info('remove obsolete state:' + objects[i]._id);
+                delObjects([objects[i]]);
+                break;
+            }
+        }
+    }
+}
+
 function extendChannel(nodeID, comClass, valueId) {
     if (!valueId || !comClass) return;
 
@@ -834,20 +854,6 @@ function extendChannel(nodeID, comClass, valueId) {
 
     // Create channel
     if (objects[channelID]) {
-        // channel exists - make sure we don't have duplicate states
-        if (!nodes[nodeID].ready) {
-            for (var i in objects) {
-                if (!objects.hasOwnProperty(i)) continue;
-                if (i.startsWith(channelID + '.')) {
-                    if (objects[i].native && objects[i].native.instance === valueId.instance && objects[i].native.index === valueId.index &&
-                    objects[i].common.name !== valueId.label) {
-                        adapter.log.info('remove obsolete state:' + objects[i]._id);
-                        delObjects([objects[i]]);
-                    }
-                }
-            }
-        }
-        
         var newNative = objects[channelID].native || {};
         newNative.nodeID = nodeID;
 
@@ -1289,6 +1295,7 @@ function main() {
         extendInclusion();
         adapter.log.debug('value added: nodeID: ' + nodeID + ' comClass: ' + JSON.stringify(comClass) + ' value: '  + JSON.stringify(valueId));
         extendChannel(nodeID, comClass, valueId);
+        cleanupValueId(nodeID, comClass, valueId);
     });
 
     zwave.on('value changed', function (nodeID, comClass, valueId) {

--- a/main.js
+++ b/main.js
@@ -840,7 +840,7 @@ function cleanupValueId(nodeID, comClass, valueId) {
             objects[i].common.name !== valueId.label) {
                 adapter.log.info('remove obsolete state:' + objects[i]._id);
                 delObjects([objects[i]]);
-                break;
+                return;
             }
         }
     }


### PR DESCRIPTION
With updates of the underlying ozwave labels of device properties are changing. You can see this massively with the switch from 1.4 to 1.6. As a result you have several states with the same valueId but different labels. This causes issues when you are still working with the old entries, they don't work anymore. The cleanup function causes some additional load during the initial scan but I think it's worth it and better then relying on the user to delete old stuff.