### PR TITLE
Suppress permission denied warnings

### DIFF
--- a/lib/preinstall.js
+++ b/lib/preinstall.js
@@ -57,11 +57,6 @@ function isOpenZWaveInstalled() {
     sysconfdir: {
       findpattern: 'zwcfg.xsd',
       locations: ["/usr/etc", "/usr/local/etc/", "/etc/"]
-    },
-    patch1125: {
-      findpattern: 'CentralScene.h',
-      locations: ["/tmp", "/usr/include/", "/usr/local/include/"],
-      searchpattern: 'createSupportedKeyAttributesValues'
     }
   }
   var usepkgconfig = true;
@@ -77,7 +72,7 @@ function isOpenZWaveInstalled() {
       var cmdfmt = "pkg-config --variable=%s libopenzwave";
       var cmd = util.format(cmdfmt, item);
       if (configs[item].searchpattern) {
-        var cmdfmt = "find %s -name '%s'";
+        var cmdfmt = "find %s -name '%s' 2> >(grep -v 'Permission denied' >&2)";
         var fp = configs[item].findpattern;
         for (var i in configs[item].locations) {
           var loc = configs[item].locations[i];
@@ -89,7 +84,7 @@ function isOpenZWaveInstalled() {
           if (!dir) continue;
           console.log('%s found in %s', fp, dir);
           sp = configs[item].searchpattern;
-          var cmdfmt = "find %s -name '%s'|grep '%s'";
+          var cmdfmt = "find %s -name '%s'|grep '%s' 2> >(grep -v 'Permission denied' >&2)";
           cmd = util.format(cmdfmt, loc, fp, sp);
           var found = doScript(cmd, true);
           if (!found) continue;
@@ -100,7 +95,7 @@ function isOpenZWaveInstalled() {
       }    
     } else {
       // 2. try using plain find
-      var cmdfmt = "find %s -name '%s'";
+      var cmdfmt = "find %s -name '%s' 2> >(grep -v 'Permission denied' >&2)";
       var fp = configs[item].findpattern;
       for (var i in configs[item].locations) {
         var loc = configs[item].locations[i];
@@ -111,10 +106,10 @@ function isOpenZWaveInstalled() {
         var dir = doScript(cmd, true);
         if (!dir) continue;
         console.log('%s found in %s', fp, dir);
-        // Check if we have a specific patch installed (for now check if patch 1125 is installed)
+        // Check if we have a specific patch installed 
         if (configs[item].searchpattern) {
           var sp = configs[item].searchpattern;
-          cmdfmt = "find %s -name '%s'|grep '%s'";
+          cmdfmt = "find %s -name '%s'|grep '%s' 2> >(grep -v 'Permission denied' >&2)";
           cmd = util.format(cmdfmt, loc, fp, sp);
           var found = doScript(cmd, true);
           if (!found) continue;

--- a/lib/preinstall.js
+++ b/lib/preinstall.js
@@ -10,7 +10,7 @@ const isRoot = typeof process.getuid === 'function' && process.getuid() === 0;
 function doScript(script, suppressException) {
   console.log('---> ' + script);
   try {
-    return(cp.execSync(script).toString());
+    return cp.execSync(script, { shell: '/bin/bash' }).toString();
   } catch(e) {
     console.log('---> ' + e.toString());
     if (!suppressException) throw e;


### PR DESCRIPTION
There are some confusing permission denied warnings because the tmp directory is used. This change suppresses them.
I also removed the patch install check as I don't see the necessity.