### PR TITLE
Deprecate and mention ioBroker.zwave2 as an alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@
 
 [![NPM](https://nodei.co/npm/iobroker.zwave.png?downloads=true)](https://nodei.co/npm/iobroker.zwave/)
 
+---
+
+# WARNING: This adapter is no longer maintained!
+
+Use [ioBroker.zwave2](https://github.com/AlCalzone/ioBroker.zwave2/) instead.
+
+_The main developer of OpenZWave has announced that he'll focus on other things from now on. As a result, OpenZWave and this adapter won't get any updates going forward._
+
+---
+
 Zwave support with openzwave.
 
 For this adapter is used rather good supported npm module: https://github.com/OpenZWave/node-openzwave-shared

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@
 
 # WARNING: This adapter is no longer maintained!
 
-Use [ioBroker.zwave2](https://github.com/AlCalzone/ioBroker.zwave2/) instead.
-
 _The main developer of OpenZWave has announced that he'll focus on other things from now on. As a result, OpenZWave and this adapter won't get any updates going forward._
+
+**Solution:** Use [ioBroker.zwave2](https://github.com/AlCalzone/ioBroker.zwave2/) instead.
+
+**Note:** If you are going to switch to *ioBroker.zwave2*, be aware that the state IDs will change. It is recommended that you use the ioBroker alias function instead of the adapter's IDs in scripts and visualizations so you can change them all in one place instead of having to edit many things.
 
 ---
 


### PR DESCRIPTION
TODO:
- [x] remove adapter from repo - https://github.com/ioBroker/ioBroker.repositories/pull/1176
- [x] Add message to info adapter - https://github.com/ioBroker/ioBroker.docs/pull/296
- [x] Archive this repo